### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 Raptor is a Web application firewall made in C, uses DFA to block SQL injection, Cross site scripting and path traversal.
 http://funguscodes.blogspot.com.br/
 
-#THis is PoC version
+# THis is PoC version
 ![Alt text](https://github.com/CoolerVoid/raptor_waf/blob/master/doc/images/help.png)
 
-#to run:
+# to run:
 $ git clone https://github.com/CoolerVoid/raptor_waf
 
 $ cd raptor_waf; make; bin/raptor
@@ -15,7 +15,7 @@ $ cd raptor_waf; make; bin/raptor
 Don't execute with "cd bin; ./raptor" use path "bin/raptor" look detail https://github.com/CoolerVoid/raptor_waf/issues/4
 
 
-#Example
+# Example
 
 Up some HTTPd server at port 80 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
